### PR TITLE
feat: Upsert comment

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ jobs:
           head-summary-json: coverage/coverage-summary.json
           coverage-threshold: 80
           check-criteria: lines, branches
+          update-if-exists: replace
           github-token: ${{ secrets.GITHUB_TOKEN }}
 ```
 
@@ -51,6 +52,7 @@ jobs:
 | `new-file-coverage-threshold` |          |                                  | See [coverage-diff docs](https://flaviusone.github.io/coverage-diff/interfaces/ConfigOptions.html). |
 | `body-header`                 |          | `''`                             | Comment body header part.                                                                           |
 | `body-footer`                 |          | `''`                             | Comment body footer part.                                                                           |
+| `update-if-exists`            |          | `append`                         | If set, create or update a comment. This must be either `replace` or `append`                       |
 | `github-token`                | YES      | `${{ github.token }}`            | GitHub token.                                                                                       |
 
 ## License

--- a/action.yaml
+++ b/action.yaml
@@ -38,6 +38,10 @@ inputs:
   new-file-coverage-threshold:
     description: See coverage-diff API doc.
     required: false
+  update-if-exists:
+    description: If set, create or update a comment. This must be either `replace` or `append`
+    default: "append"
+    required: false
 
 runs:
   using: node16


### PR DESCRIPTION
## Background

A long-lived Pull Request will create a lot of comments from this action.
This can cause a situation that valuable comments are hidden.

## Description

This pull pequest resolves to create many comments by updating comment.

1. Find own comment from issue/pull request comments
2. If the comment is found, updateComment
3. Else createComment

Inspired from: https://github.com/aki77/actions-replace-comment

## Example:

<img width="896" alt="image" src="https://github.com/Quramy/simple-coverage-diff-action/assets/1213991/b01a4fd6-1cd5-4345-81fc-22af5c58b1f9">

https://github.com/mtgto/example-simple-coverage-diff-action/pull/1
